### PR TITLE
Benutze innoQ parent POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>com.innoq</groupId>
         <artifactId>innoq-oss-parent</artifactId>
-        <version>1-SNAPSHOT</version>
+        <version>1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Habe einen Parent POM herausgezogen, damit erspart Ihr Euch license und organization.

Außerdem habe ich dem POM ein description-Tag gegeben, ich glaube, das ist Pflicht.  Solltet Ihr ggf. auch in den POMs der Module durchführen.
