### PR TITLE
upgrade innoQ parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-  Copyright (C) 2012 innoQ Deutschland GmbH
+  Copyright (C) 2012-2015 innoQ Deutschland GmbH
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.innoq</groupId>
         <artifactId>innoq-oss-parent</artifactId>
-        <version>1</version>
+        <version>2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.innoq.liqid</groupId>


### PR DESCRIPTION
Version 1 uses Sonatype's OSS parent as its parent and inherits the
setting for OSSRH.  Sonatype's OSS parent has been deprecated and is no
longer maintained.