### PR TITLE
Code quality fix - Strings literals should be placed on the left side when checking for equality.

### DIFF
--- a/ldap-connector/src/com/innoq/ldap/connector/LdapHelper.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapHelper.java
@@ -313,7 +313,7 @@ public class LdapHelper implements Helper {
      */
     public Set<Node> findUsers(final String uid) {
         QueryBuilder qb = new LdapQueryBuilder();
-        if (uid.equals("*")) {
+        if ("*".equals(uid)) {
             qb.append(LdapKeys.OBJECT_CLASS, userObjectClass);
         } else {
             qb.append(LdapKeys.OBJECT_CLASS, userObjectClass);
@@ -389,7 +389,7 @@ public class LdapHelper implements Helper {
      */
     public Set<Node> findGroups(final String cn) {
         QueryBuilder qb = new LdapQueryBuilder();
-        if (cn.equals("*")) {
+        if ("*".equals(cn)) {
             qb.append(LdapKeys.OBJECT_CLASS, groupObjectClass);
         } else {
             qb.append(LdapKeys.OBJECT_CLASS, groupObjectClass);
@@ -1003,7 +1003,7 @@ public class LdapHelper implements Helper {
         Enumeration<String> keys = attrs.getIDs();
         while (keys.hasMoreElements()) {
             k = keys.nextElement();
-            if (getAttributeOrNa(attrs, k).equals("null")) {
+            if ("null".equals(getAttributeOrNa(attrs, k))) {
                 log.write("filterForNullAttributes removing " + k + " " + attrs.get(k) + "\n", LdapHelper.class);
                 attrs.remove(k);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1132

Please let me know if you have any questions.

Faisal Hameed