### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/ldap-connector/src/com/innoq/ldap/connector/LdapHelper.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapHelper.java
@@ -76,6 +76,16 @@ public class LdapHelper implements Helper {
     private long validationCount;
     private long creationCount;
     private long deletionCount;
+    
+    /**
+     * Returns an Instance of the LdapHelper.
+     *
+     * @param instance the identifyer of the LDAP Instance (e.g. ldap1)
+     */
+    public LdapHelper(String instance) {
+        this.instanceName = instance;
+        checkDirs();
+    }
 
     public static LdapHelper getInstance() {
         String defaultLdap = Configuration.getProperty("default.ldap");
@@ -110,15 +120,6 @@ public class LdapHelper implements Helper {
         return ldaps;
     }
 
-    /**
-     * Returns an Instance of the LdapHelper.
-     *
-     * @param instance the identifyer of the LDAP Instance (e.g. ldap1)
-     */
-    public LdapHelper(String instance) {
-        this.instanceName = instance;
-        checkDirs();
-    }
 
     /**
      * Sets the Log of that LdapHelper.

--- a/ldap-connector/src/com/innoq/ldap/connector/LdapKeys.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapKeys.java
@@ -17,7 +17,6 @@ package com.innoq.ldap.connector;
 
 public class LdapKeys {
 
-	private LdapKeys() {}
 	
     public static final String USER_OBJECTCLASS = "person";
     public static final String ASTERISK = "*";
@@ -38,4 +37,7 @@ public class LdapKeys {
     public static final String GROUP_MEMBER_ATTRIBUTE = "member";
     public static final String DEFAULT_JABBER_SERVER = "jabber.example.com";
     public static final String USER_UID_FORMAT = "%s=%s,%s";
+    
+    private LdapKeys() {}
+    
 }

--- a/ldap-connector/src/com/innoq/ldap/connector/LdapNode.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapNode.java
@@ -37,6 +37,13 @@ public class LdapNode implements Node {
     protected String modifyTimestamp = null;
     protected String modifiersName = null;
     protected String cn = null;
+    
+    /**
+     * Basic Constructor.
+     */
+    public LdapNode() {
+        objectClasses = new HashSet<>();
+    }
 
     /**
      * Returns an entry for a given key.
@@ -57,12 +64,6 @@ public class LdapNode implements Node {
         return null;
     }
 
-    /**
-     * Basic Constructor.
-     */
-    public LdapNode() {
-        objectClasses = new HashSet<>();
-    }
 
     /**
      * There might be always a root entry (uid or cn).

--- a/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
@@ -34,9 +34,9 @@ import java.util.logging.Logger;
 
 public class ObjectCache {
 	
-	private ObjectCache() {}
-
     private final static Logger LOG = Logger.getLogger(ObjectCache.class.getName());
+    
+    private ObjectCache() {}
 
     /**
      * Loads a Node from Cache File.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed