### PR TITLE
Multiple code quality fix-2

### DIFF
--- a/ldap-connector/src/com/innoq/ldap/connector/LdapQueryBuilder.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapQueryBuilder.java
@@ -20,7 +20,9 @@
 package com.innoq.ldap.connector;
 
 import com.innoq.liqid.model.QueryBuilder;
+
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.TreeMap;
 
 public class LdapQueryBuilder implements QueryBuilder {
@@ -38,8 +40,8 @@ public class LdapQueryBuilder implements QueryBuilder {
         if (elements.size() > 1) {
             sb.append("(&");
         }
-        for (String key : elements.keySet()) {
-            sb.append("(").append(key).append("=").append(elements.get(key)).append(")");
+        for (Entry<String, String> element : elements.entrySet()) {
+            sb.append("(").append(element.getKey()).append("=").append(element.getValue()).append(")");
         }
         if (elements.size() > 1) {
             sb.append(")");

--- a/ldap-connector/src/com/innoq/ldap/util/App.java
+++ b/ldap-connector/src/com/innoq/ldap/util/App.java
@@ -23,7 +23,7 @@ import java.util.Date;
 
 public class App {
 
-    private final static String HR = "------------------------------------------------------------------------------";
+    private static final String HR = "------------------------------------------------------------------------------";
     private final String out = System.getProperty("user.home") + SEP + ".liqid" + SEP + "liqid.properties";
     private static PrintStream outputStream = System.out;
     private static boolean isTest = false;

--- a/utils/src/main/java/com/innoq/liqid/log/LogConsole.java
+++ b/utils/src/main/java/com/innoq/liqid/log/LogConsole.java
@@ -25,7 +25,7 @@ import java.util.logging.Logger;
 
 public class LogConsole implements Log {
 
-    private final static Logger LOG = Logger.getLogger(LogConsole.class.getName());
+    private static final Logger LOG = Logger.getLogger(LogConsole.class.getName());
 
     public LogConsole(){
         LOG.info(">> starting...");

--- a/utils/src/main/java/com/innoq/liqid/utils/Configuration.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/Configuration.java
@@ -19,6 +19,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Properties;
 
 /**
@@ -27,9 +28,9 @@ import java.util.Properties;
  */
 public class Configuration {
 
-    public final static String SEP = System.getProperty("file.separator");
-    private final static String TMP_DIR = System.getProperty("java.io.tmpdir");
-    private final static String DEFAULT_LOCATION = System.getProperty("user.home") + SEP + ".liqid" + SEP + "liqid.properties";
+    public static final String SEP = System.getProperty("file.separator");
+    private static final String TMP_DIR = System.getProperty("java.io.tmpdir");
+    private static final String DEFAULT_LOCATION = System.getProperty("user.home") + SEP + ".liqid" + SEP + "liqid.properties";
     private static Configuration instance = new Configuration();
     private String tmpDir = null;
     private String cacheDir = null;
@@ -125,9 +126,9 @@ public class Configuration {
 
     private static String getEnvFileLocation() {
         Map<String, String> env = System.getenv();
-        for (String envName : env.keySet()) {
-            if ("LIQID_PROPERTIES".equals(envName)) {
-                return env.get(envName);
+        for (Entry<String, String> prop : env.entrySet()) {
+            if ("LIQID_PROPERTIES".equals(prop.getKey())) {
+                return prop.getValue();
             }
         }
         return DEFAULT_LOCATION;

--- a/utils/src/main/java/com/innoq/liqid/utils/KeyValueStore.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/KeyValueStore.java
@@ -34,7 +34,7 @@ import java.util.logging.Logger;
 
 public class KeyValueStore implements Serializable {
 
-    private final static Logger LOG = Logger.getLogger(KeyValueStore.class.getName());
+    private static final Logger LOG = Logger.getLogger(KeyValueStore.class.getName());
     private Map<String, String> storage;
 
     public KeyValueStore() {

--- a/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
@@ -36,7 +36,7 @@ public class ObjectCache {
 	
 	private ObjectCache() {}
 
-    private final static Logger LOG = Logger.getLogger(ObjectCache.class.getName());
+    private static final Logger LOG = Logger.getLogger(ObjectCache.class.getName());
 
     /**
      * Loads a Node from Cache File.


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2864 - "entrySet()" should be iterated when both the key and value are needed.
squid:ModifiersOrderCheck - Modifiers should be declared in the correct order.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
https://dev.eclipse.org/sonar/rules/show/squid:ModifiersOrderCheck

Please let me know if you have any questions.

Faisal Hameed