### PR TITLE
Multiple code quality fix-3

### DIFF
--- a/ldap-connector/src/com/innoq/ldap/connector/LdapEntry.java
+++ b/ldap-connector/src/com/innoq/ldap/connector/LdapEntry.java
@@ -17,7 +17,7 @@ package com.innoq.ldap.connector;
 
 public class LdapEntry extends LdapNode implements Comparable<LdapEntry> {
 
-    public String owner;
+    private String owner;
 
     public LdapEntry(String cn, String owner) {
         super();

--- a/utils/src/main/java/com/innoq/liqid/utils/KeyValueStore.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/KeyValueStore.java
@@ -21,7 +21,6 @@ package com.innoq.liqid.utils;
 
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -34,6 +33,8 @@ import java.util.logging.Logger;
 
 public class KeyValueStore implements Serializable {
 
+    private static final long serialVersionUID = -843713925958974030L;
+    
     private final static Logger LOG = Logger.getLogger(KeyValueStore.class.getName());
     private Map<String, String> storage;
 

--- a/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
+++ b/utils/src/main/java/com/innoq/liqid/utils/ObjectCache.java
@@ -23,7 +23,6 @@ package com.innoq.liqid.utils;
 import com.innoq.liqid.model.Node;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
squid:UselessImportCheck - Useless imports should be removed.
squid:S2057 - "Serializable" classes should have a version id.
You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
https://dev.eclipse.org/sonar/rules/show/squid:S2057

Please let me know if you have any questions.

Faisal Hameed