### PR TITLE
Fixed NullPointerException when filling attributes in empty group

### DIFF
--- a/ldap-connector/src/main/java/com/innoq/ldap/connector/LdapHelper.java
+++ b/ldap-connector/src/main/java/com/innoq/ldap/connector/LdapHelper.java
@@ -1134,12 +1134,16 @@ public class LdapHelper implements Helper {
                     group.setCn(getAttributeOrNa(attributes, key));
                 }
             }
-            NamingEnumeration<?> members = attributes.get(groupMemberAttribut).getAll();
-            while (members.hasMoreElements()) {
-                String memberDN = (String) members.nextElement();
-                member = new LdapUser(getUidForDN(memberDN), this);
-                member.setDn(memberDN);
-                group.addUser(member);
+
+	    Attribute membersAttribute = attributes.get(groupMemberAttribut);
+	    if (membersAttribute != null) {
+	    	NamingEnumeration<?> members = membersAttribute.getAll();
+            	while (members.hasMoreElements()) {
+                    String memberDN = (String) members.nextElement();
+                    member = new LdapUser(getUidForDN(memberDN), this);
+                    member.setDn(memberDN);
+                    group.addUser(member);
+		}
             }
         } catch (NamingException ex) {
             handleNamingException(group, ex);


### PR DESCRIPTION
When a group is empty the members attribute will be null (at least in our LDAP server).
Added check to see if the members attribute is null.